### PR TITLE
Replace removed method File.exists? for File.exist?

### DIFF
--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -22,7 +22,7 @@ module Fastlane
 
             if params[:verbose] 
               # Checking for output files
-              if File.exists?(avd_controller.output_file.path) 
+              if File.exist?(avd_controller.output_file.path)
                 UI.message([
                   "Successfully created tmp output file for AVD:", 
                   avd_schemes[i].avd_name + ".", 
@@ -169,7 +169,7 @@ module Fastlane
               for i in 0...avd_schemes.length
                 if params[:verbose] 
                   # Display AVD output
-                  if (File.exists?(avd_controllers[i].output_file.path))
+                  if (File.exist?(avd_controllers[i].output_file.path))
                     UI.message(["Displaying log for AVD:", avd_schemes[i].avd_name].join(" ").red)
                     UI.message(avd_controllers[i].output_file.read.blue)
                   end
@@ -222,7 +222,7 @@ module Fastlane
 
               if params[:verbose]
                 # Display AVD output
-                if (File.exists?(avd_controllers[i].output_file.path))
+                if (File.exist?(avd_controllers[i].output_file.path))
                   UI.message("Displaying log from AVD to console:".green)
                   UI.message(avd_controllers[i].output_file.read.blue)
 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
@@ -85,7 +85,7 @@ module Fastlane
             sh_create_avd_additional_options].join(" ")
 
           avd_controller.output_file = Tempfile.new('emulator_output')
-          avd_output = File.exists?(avd_controller.output_file) ? ["&>", avd_controller.output_file.path, "&"].join("") : "&>/dev/null &"
+          avd_output = File.exist?(avd_controller.output_file) ? ["&>", avd_controller.output_file.path, "&"].join("") : "&>/dev/null &"
           
           avd_controller.command_start_avd = [
            sh_launch_emulator_binary, 

--- a/lib/fastlane/plugin/automated_test_emulator_run/provider/avd_setup_provider.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/provider/avd_setup_provider.rb
@@ -117,7 +117,7 @@ module Fastlane
         end
 
         def self.read_avd_setup(params)
-          if File.exists?(File.expand_path("#{params[:AVD_setup_path]}"))
+          if File.exist?(File.expand_path("#{params[:AVD_setup_path]}"))
             file = File.open(File.expand_path("#{params[:AVD_setup_path]}"), "rb")
             json = file.read
             file.close


### PR DESCRIPTION
Add support for ruby 3.2. Method File.exists? was removed in ruby version 3.2. https://rubyreferences.github.io/rubychanges/3.2.html